### PR TITLE
Updated build.gradle to make it compatible with fresh Gradle tools

### DIFF
--- a/dependencies/mobileprefs/build.gradle
+++ b/dependencies/mobileprefs/build.gradle
@@ -1,8 +1,7 @@
 buildscript {
 	repositories {
-		maven {
-			url "http://repo1.maven.org/maven2/"
-		}
+		mavenCentral()
+		google()
 	}
 	
 	dependencies {
@@ -25,6 +24,6 @@ android {
 }
 
 dependencies {
-	compile fileTree(dir: 'libs', include: ['*.jar'])
-	compile project(':deps:extension-api')
+	api fileTree(dir: 'libs', include: ['*.jar'])
+	api project(':deps:extension-api')
 }


### PR DESCRIPTION
- Repositories changed to the standard repository paths
- Deprecated 'compile' dependency changed to 'api'